### PR TITLE
fix: add thread safety to TryLookup by locking _storeLock

### DIFF
--- a/src/Mzinga/Core/FixedCache.cs
+++ b/src/Mzinga/Core/FixedCache.cs
@@ -114,20 +114,23 @@ namespace Mzinga.Core
 
         public bool TryLookup(TKey key, [NotNullWhen(returnValue: true)] out TEntry? entry)
         {
-            if (_dict.TryGetValue(key, out FixedCacheEntry<TKey, TEntry>? wrappedEntry))
+            lock (_storeLock)
             {
-                entry = wrappedEntry.Entry;
+                if (_dict.TryGetValue(key, out FixedCacheEntry<TKey, TEntry>? wrappedEntry))
+                {
+                    entry = wrappedEntry.Entry;
 #if DEBUG
-                Metrics.Hit();
+                    Metrics.Hit();
 #endif
-                return true;
-            }
+                    return true;
+                }
 #if DEBUG
-            Metrics.Miss();
+                Metrics.Miss();
 #endif
 
-            entry = default;
-            return false;
+                entry = default;
+                return false;
+            }
         }
 
         public void Clear()


### PR DESCRIPTION
This commit addresses an intermittent error that occurs in the `FixedCache.TryLookup` method when multiple threads access it simultaneously. The error was caused by `wrappedEntry` being null due to race conditions. To fix this, a `lock (_storeLock)` was added around the `TryLookup` method to ensure thread-safe access, similar to other parts of the code that already use this locking mechanism.

Closes #129.